### PR TITLE
custom events should not fire when a parent event fires

### DIFF
--- a/src/ce/ajneb97/managers/CustomEventListener.java
+++ b/src/ce/ajneb97/managers/CustomEventListener.java
@@ -4,20 +4,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.EventExecutor;
-import org.bukkit.plugin.RegisteredListener;
-
 import ce.ajneb97.ConditionalEvents;
 import ce.ajneb97.Variable;
 import ce.ajneb97.eventos.Evento;
@@ -53,6 +46,14 @@ public class CustomEventListener implements Listener{
 		Class<?> clase = event.getClass();
 //		Bukkit.getConsoleSender().sendMessage("Encuentra evento con clase: "+clase.getCanonicalName());
 //		Bukkit.getConsoleSender().sendMessage("LLAMA EVENTO! y Encuentra metodos:");
+		try {
+			if (!Class.forName(e.getCustomEvent()).isAssignableFrom(clase)) {
+			    return;
+			}
+		} catch (ClassNotFoundException e1) {
+			// TODO Auto-generated catch block
+			e1.printStackTrace();
+		}
 		List<String> variablesToCapture = e.getVariablesToCapture();
 		ArrayList<Variable> variablesToCaptureRemplazadas = new ArrayList<Variable>();
 		for(String linea : variablesToCapture) {


### PR DESCRIPTION
This PR is in response to an issue raised on the Parkour plugin's discord and is a fix for an issue where custom events can sometimes be detected incorrectly.

Most events will have a handler list contained within the event class, however some events (and some plugins) have event classes that inherit the handler list from a parent class.

Parkour is one such plugin where the handler list is in a parent class. So when attempting to listen for one particular Parkour event, for example `PlayerFinishCourseEvent`, ConditionalEvents is firing on _every_ Parkour event that occurs.

There is a better explanation of it here:
![image](https://user-images.githubusercontent.com/6975392/160655519-d431605d-3db1-4ec4-ab9b-45be20c93fa9.png)

This fix will cause ConditionalEvents to only action the event if it exactly matches the custom event.

